### PR TITLE
Envia tempo do MATLAB para o arduino

### DIFF
--- a/arduino/solenoide_controller/solenoide_controller.ino
+++ b/arduino/solenoide_controller/solenoide_controller.ino
@@ -22,12 +22,10 @@ class SimpleState{
     void Update(){
         unsigned long currentMillis = millis();
         if((currentMillis-previousMillis)>= offTime){
-          Serial.print("SIMPLES ");
           digitalWrite(pin, HIGH);
           delay(50);
           digitalWrite(pin, LOW);
           this->finished = true;
-          Serial.println("FIM");
         }
     }
 };
@@ -62,13 +60,11 @@ class TraceState{
         digitalWrite(this->pin, LOW);
         this->pressed = false;
         finished = true;
-        Serial.println("SOLTOU");
       }
       // Aperta
       if(!pressed && !finished && (currentMillis-previousMillis)>= offTime){
         digitalWrite(this->pin, HIGH);
         this->pressed = true;
-        Serial.println("APERTOU");
       }
     }
     void Soltar(unsigned long prev_free){

--- a/arduino/solenoide_controller/solenoide_controller.ino
+++ b/arduino/solenoide_controller/solenoide_controller.ino
@@ -90,13 +90,15 @@ void setup() {
   // obtém o tempo do matlab
   while(true){
     if (Serial.available() > 0) {
+      if(offtime != 0){
+        break;
+      }
       incomingByte = Serial.read();
       if(incomingByte == 'a'){
         String str = Serial.readStringUntil('b');
         offtime = str.toInt();
         Serial.print(offtime);
         incomingByte = '\0';
-        break;
       }
     }
   }

--- a/src/press_buttons.m
+++ b/src/press_buttons.m
@@ -39,16 +39,16 @@ function press_buttons(vid, galileo)
     % tempo
     [tempo_aperta, tempo_espera] = chose_times(nivel);
     % envia o tempo para o arduino
-%     while true
-%         time_to_send = strcat('a', int2str(tempo_aperta), 'b');
-%         fprintf(galileo, "%s", time_to_send);
-%         if (galileo.BytesAvailable > 0)
-%             out = fscanf(galileo,'%c',galileo.BytesAvailable);
-%             if(str2num(out)==tempo_aperta)
-%                 break;
-%             end
-%         end
-%     end
+    while true
+        time_to_send = strcat('a', num2str(tempo_aperta*1000), 'b');
+        fprintf(galileo, "%s", time_to_send);
+        if (galileo.BytesAvailable > 0)
+            out = fscanf(galileo,'%c',galileo.BytesAvailable);
+            if(str2num(out)==tempo_aperta*1000)
+                break;
+            end
+        end
+    end
     R = 1;
     G = 2;
     B = 3;

--- a/src/rastro_detection.m
+++ b/src/rastro_detection.m
@@ -52,7 +52,7 @@ function holding_button = rastro_detection(galileo, imgO, holding_button)
 
         %segura botao
         holding_button = true;
-
+        
         fprintf(galileo,'%c', APERTA_SEM_SOLTAR);  
     end
 


### PR DESCRIPTION
Esta alteração permite que o tempo do jogo seja enviado pelo MATLAB ao arduino, e o arduino envia uma resposta confirmando que o tempo recebido foi o correto.