### PR TITLE
Corrige offtime do rastro e organiza parte do codigo de tempo

### DIFF
--- a/arduino/solenoide_controller/solenoide_controller.ino
+++ b/arduino/solenoide_controller/solenoide_controller.ino
@@ -74,7 +74,8 @@ class TraceState{
 };
 
 int L1 = 3;
-unsigned long offtime = 0;
+unsigned long offtime_simple = 0;
+unsigned long offtime_rastro = 1200;
 unsigned char incomingByte = '\0';
 
 int freeStates[N_SIMPLE_STATES]={1,1,1,1,1,1,1,1,1,1};
@@ -90,14 +91,14 @@ void setup() {
   // obtém o tempo do matlab
   while(true){
     if (Serial.available() > 0) {
-      if(offtime != 0){
+      if(offtime_simple != 0){
         break;
       }
       incomingByte = Serial.read();
       if(incomingByte == 'a'){
         String str = Serial.readStringUntil('b');
-        offtime = str.toInt();
-        Serial.print(offtime);
+        offtime_simple = str.toInt();
+        Serial.print(offtime_simple);
         incomingByte = '\0';
       }
     }
@@ -105,12 +106,12 @@ void setup() {
   
   for(int i=0; i<N_SIMPLE_STATES; i++){
     freeStates[i] = 1;
-    simpleStates[i] = new SimpleState(millis(), offtime);
+    simpleStates[i] = new SimpleState(millis(), offtime_simple);
     simpleStates[i]->finished = true;
   }
 
   for(int i=0; i<N_TRACE_STATES; i++){
-    traceStates[i] = new TraceState(millis(), offtime);
+    traceStates[i] = new TraceState(millis(), offtime_rastro);
     traceStates[i]->finished = true;
   }
 
@@ -125,14 +126,14 @@ void loop(){
     // o mais rápido possível
     if(incomingByte == char(100)){
       ind=get_simpleStates_index();
-      simpleStates[ind] = new SimpleState(millis(), offtime);
+      simpleStates[ind] = new SimpleState(millis(), offtime_simple);
       incomingByte = '\0';
     }
 
     // Estado de rastro: Aperta sem soltar
     if(incomingByte == char(101)){
       ind = get_traceStates_index();
-      traceStates[ind] = new TraceState(millis(), offtime);
+      traceStates[ind] = new TraceState(millis(), offtime_rastro);
       traceQueue.push(ind);
       incomingByte = '\0';
     }
@@ -148,7 +149,7 @@ void loop(){
     }
 
     if(incomingByte == char(109)){
-      Serial.print(offtime);
+      Serial.print(offtime_simple);
     }
     
   }

--- a/src/check_arduino_time.m
+++ b/src/check_arduino_time.m
@@ -1,0 +1,40 @@
+function check_arduino_time(galileo, tempo_aperta)
+    % FunÃ§Ã£o que trata do envio de tempos para o arduino
+
+    CHECA_TIME_SIMPLE = char(109);
+    
+    out = 0;
+
+    % checa se o arduino já estão rodando o código
+    % com o tempo correto (isso pode ocorrer por ex.
+    % quando damos CTRL + C encerrando o código do matlab,
+    % mas o código e o tempo corretos continuam no arduino)
+    fprintf(galileo,'%c', CHECA_TIME_SIMPLE);
+    pause(0.5); % um tempo de espera para a resposta chegar
+    if (galileo.BytesAvailable > 0)
+        out = fscanf(galileo,'%c',galileo.BytesAvailable);
+        out = str2num(out)
+    end
+    
+    % envia o tempo para o arduino se necessÃ¡rio
+    while true
+        % se o arduino já tiver o tempo correto, não precisa enviar
+        if(out==tempo_aperta*1000)
+           break;
+        elseif out~=0
+            texto_erro = ['Arduino já possui um tempo, mas é diferente do ' ...
+                          'tempo do nível atual. Por favor, dê reboot no Arduino.'];
+            error(texto_erro);
+        end
+        % envia o tempo para o arduino 
+        time_to_send = strcat('a', num2str(tempo_aperta*1000), 'b');
+        fprintf(galileo, "%s", time_to_send);
+        if (galileo.BytesAvailable > 0)
+            out = fscanf(galileo,'%c',galileo.BytesAvailable);
+            if(str2num(out)==tempo_aperta*1000)
+                break;
+            end
+        end
+    end
+
+end

--- a/src/press_buttons.m
+++ b/src/press_buttons.m
@@ -36,40 +36,12 @@ function press_buttons(vid, galileo)
     APERTA_SEM_SOLTAR = char(101);
     SOLTA = char(102);
 
-    CHECA_TIME = char(109);
-
     % tempo
     [tempo_aperta, tempo_espera] = chose_times(nivel);
-    
-    out = 0;
 
-    % checa se o arduino já está rodando o código
-    % com o tempo correto (isso pode ocorrer por ex.
-    % quando damos CTRL + C encerrando o código do matlab,
-    % mas o código e o tempo corretos continuam no arduino)
-    fprintf(galileo,'%c', CHECA_TIME);
-    pause(0.5); % um tempo de espera para a resposta chegar
-    if (galileo.BytesAvailable > 0)
-        out = fscanf(galileo,'%c',galileo.BytesAvailable);
-        out = str2num(out)
-    end
-    
-    % envia o tempo para o arduino se necessário
-    while true
-        % se o arduino já tiver o tempo correto, não precisa enviar
-        if(out==tempo_aperta*1000)
-           break; 
-        end
-        % envia o tempo para o arduino 
-        time_to_send = strcat('a', num2str(tempo_aperta*1000), 'b');
-        fprintf(galileo, "%s", time_to_send);
-        if (galileo.BytesAvailable > 0)
-            out = fscanf(galileo,'%c',galileo.BytesAvailable);
-            if(str2num(out)==tempo_aperta*1000)
-                break;
-            end
-        end
-    end
+    % envia os tempos para o arduino, ou verifica se os tempos
+    % estão corretos, caso o arduino já possua o tempo
+    check_arduino_time(galileo, tempo_aperta);
     
     R = 1;
     G = 2;


### PR DESCRIPTION
Organiza melhor o envio de tempo através da função check_arduino_time e corrige o offtime no código do arduino, tendo uma variável diferente e um tempo diferente para o rastro. Antes era considerado o mesmo tempo para rastro e aperto simples.